### PR TITLE
Add YAML schema comments for config exports

### DIFF
--- a/knowledge/YAML_SUPPORT.md
+++ b/knowledge/YAML_SUPPORT.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-DigitShowDST now supports both JSON and YAML formats for calibration factors and control scripts. Users can seamlessly load and save configuration files in either format through the UI dialogs.
+DigitShowDST now supports both JSON and YAML formats for calibration factors and
+control scripts. Users can seamlessly load and save configuration files in
+either format through the UI dialogs.
 
 ## Supported File Extensions
 
@@ -14,25 +16,33 @@ DigitShowDST now supports both JSON and YAML formats for calibration factors and
 ### Automatic Format Detection
 
 The system automatically detects the file format based on the file extension:
+
 - `.json` files are parsed as JSON
 - `.yml` and `.yaml` files are parsed as YAML
 - Unknown extensions default to JSON
 
 ### Unified Loading
 
-Both calibration factor and control script dialogs can load files in either format:
-- **Calibration Factor Dialog**: Click "Load" button and select `.json`, `.yml`, or `.yaml` files
-- **Control Script Dialog**: Click "Load" button and select `.json`, `.yml`, or `.yaml` files
+Both calibration factor and control script dialogs can load files in either
+format:
+
+- **Calibration Factor Dialog**: Click "Load" button and select `.json`, `.yml`,
+  or `.yaml` files
+- **Control Script Dialog**: Click "Load" button and select `.json`, `.yml`, or
+  `.yaml` files
 
 ### Format-Specific Saving
 
-When saving, the file format is automatically determined by the chosen file extension in the save dialog:
+When saving, the file format is automatically determined by the chosen file
+extension in the save dialog:
+
 - Save as `.json` → JSON format
 - Save as `.yml` or `.yaml` → YAML format
 
 ### Data Preservation
 
 Round-trip conversion between JSON and YAML preserves all data:
+
 - Load a JSON file → Save as YAML → No data loss
 - Load a YAML file → Save as JSON → No data loss
 
@@ -41,6 +51,7 @@ Round-trip conversion between JSON and YAML preserves all data:
 ### Calibration Factor Files
 
 **JSON Format** (`calibration.json`):
+
 ```json
 {
   "calibration_data": [
@@ -61,7 +72,9 @@ Round-trip conversion between JSON and YAML preserves all data:
 ```
 
 **YAML Format** (`calibration.yaml`):
+
 ```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/takker99/DigitShowDST/<commit>/schemas/calibration_factor.schema.json
 calibration_data:
   - channel: 0
     cal_a: 0.0
@@ -77,6 +90,7 @@ initial_specimen:
 ### Control Script Files
 
 **JSON Format** (`control.json`):
+
 ```json
 {
   "$schema": "../schemas/control_script.schema.json",
@@ -97,7 +111,9 @@ initial_specimen:
 ```
 
 **YAML Format** (`control.yaml`):
+
 ```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/takker99/DigitShowDST/<commit>/schemas/control_script.schema.json
 steps:
   - name: Initial consolidation
     use: constant_tau_consolidation
@@ -113,7 +129,8 @@ steps:
 
 ### Core Functions
 
-The YAML support is implemented through three main functions in `control/json.hpp`:
+The YAML support is implemented through three main functions in
+`control/json.hpp`:
 
 1. **`DetectFormat(filepath)`**: Detects file format from extension
 2. **`LoadConfigFile(filepath)`**: Loads JSON or YAML file into a ryml tree
@@ -122,6 +139,7 @@ The YAML support is implemented through three main functions in `control/json.hp
 ### File Dialog Filters
 
 Both dialogs now use unified file filters:
+
 ```
 Config Files (*.json;*.yml;*.yaml)|*.json;*.yml;*.yaml|
 JSON Files (*.json)|*.json|
@@ -154,6 +172,7 @@ All Files (*.*)|*.*||
 ## Testing
 
 Comprehensive test suite (`test_yaml_support.cpp`) covers:
+
 - Format detection for all extensions
 - JSON file loading
 - YAML file loading
@@ -166,6 +185,7 @@ Comprehensive test suite (`test_yaml_support.cpp`) covers:
 ## Sample Files
 
 Example files are provided in `test_data/`:
+
 - `sample_calibration.json` / `sample_calibration.yaml`
 - `sample_control.json` / `sample_control.yaml`
 
@@ -186,13 +206,14 @@ Example files are provided in `test_data/`:
 ## Schema Support
 
 - JSON files can reference the schema via `$schema` field
-- YAML files don't require schema reference (but the same schema applies)
-- VS Code provides autocomplete for JSON files with schema
-- YAML validation follows the same schema rules
+- YAML files include a `# yaml-language-server: $schema=...` comment at the top
+  on save
+- The YAML schema URL is pinned to the build commit (the `version` commit id
+  without `-dirty`)
+- VS Code provides autocomplete/validation for both JSON and YAML formats
 
 ## Known Limitations
 
-- Schema reference (`$schema`) is preserved only in JSON format
 - YAML comments are not preserved when converting to JSON and back
 - File format is determined solely by extension (no content detection)
 
@@ -205,6 +226,7 @@ Example files are provided in `test_data/`:
 
 ## References
 
-- JSON Schema: `schemas/calibration_factor.schema.json`, `schemas/control_script.schema.json`
+- JSON Schema: `schemas/calibration_factor.schema.json`,
+  `schemas/control_script.schema.json`
 - Control specifications: `knowledge/control_specifications.md`
 - YAML migration guide: `knowledge/ctl_to_yaml_migration.md`

--- a/src/ApiServer.cpp
+++ b/src/ApiServer.cpp
@@ -24,6 +24,7 @@
 #include "StdAfx.h"
 
 #include "ApiServer.hpp"
+#include "control/json.hpp"
 #include "openapi_spec.hpp"
 #include "version_info.hpp"
 #include <chrono>
@@ -427,35 +428,35 @@ ApiConfig ApiServer::load_config(const std::string &config_path) noexcept
     try
     {
         const std::filesystem::path path(config_path);
+        const auto format = DetectFormat(path);
+        const auto schema_url = version_info::build_schema_url("schemas/api_config.schema.json");
 
         // Check if the file exists
         if (!std::filesystem::exists(path))
         {
             spdlog::warn("API config file not found: {}. Creating with default values.", config_path);
 
-            // Create default config JSON
-            json default_json = {{"$schema", "schemas/api_config.schema.json"},
-                                 {"enabled", config.enabled},
-                                 {"host", config.host},
-                                 {"port", config.port},
-                                 {"update_interval_ms", config.update_interval_ms},
-                                 {"cors_enabled", config.cors_enabled},
-                                 {"max_connections", config.max_connections}};
+            ryml::Tree tree;
+            ryml::NodeRef root = tree.rootref();
+            root |= ryml::MAP;
+            root["$schema"] << "schemas/api_config.schema.json";
+            root["enabled"] << config.enabled;
+            root["host"] << config.host;
+            root["port"] << config.port;
+            root["update_interval_ms"] << config.update_interval_ms;
+            root["cors_enabled"] << config.cors_enabled;
+            root["max_connections"] << config.max_connections;
 
             // Add version information (git commit hash)
             const auto version = version_info::get_version_string();
             if (!version.empty())
             {
-                default_json["version"] = version;
+                root["version"] << version;
                 spdlog::debug("Added version info to API config: {}", version);
             }
 
-            // Write default config to file
-            std::ofstream out_file(path);
-            if (out_file.is_open())
+            if (SaveConfigFile(path, tree, format, schema_url))
             {
-                out_file << default_json.dump(2) << "\n"; // Pretty print with 2-space indent
-                out_file.close();
                 spdlog::info("Created default API config file: {}", config_path);
             }
             else
@@ -475,7 +476,21 @@ ApiConfig ApiServer::load_config(const std::string &config_path) noexcept
         }
 
         json j;
-        file >> j;
+        if (format == FileFormat::YAML)
+        {
+            std::string content((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+            const auto json_content = yaml_to_json(content);
+            j = json::parse(json_content, nullptr, false);
+            if (j.is_discarded())
+            {
+                spdlog::error("Failed to parse API config YAML: {}", config_path);
+                return config;
+            }
+        }
+        else
+        {
+            file >> j;
+        }
 
         if (j.contains("enabled"))
             config.enabled = j["enabled"];

--- a/src/CalibrationFactor.cpp
+++ b/src/CalibrationFactor.cpp
@@ -535,8 +535,9 @@ void CCalibrationFactor::OnBUTTONCFSaveConfig()
 
             // Detect format from file extension
             const auto format = DetectFormat(std::filesystem::path(wpath));
+            const auto schema_url = version_info::build_schema_url("schemas/calibration_factor.schema.json");
 
-            if (!SaveConfigFile(std::filesystem::path(wpath), tree, format))
+            if (!SaveConfigFile(std::filesystem::path(wpath), tree, format, schema_url))
             {
                 spdlog::error("Failed to save calibration config file: {}", path_u8);
                 AfxMessageBox(_T("Failed to save calibration config file."), MB_ICONEXCLAMATION | MB_OK);

--- a/src/Control_File.cpp
+++ b/src/Control_File.cpp
@@ -344,12 +344,16 @@ void CControl_File::OnButtonExport()
 
     const std::wstring wpath = std::wstring(dlg.GetPathName().GetString());
     const auto format = DetectFormat(std::filesystem::path(wpath));
+    const auto schema_url = version_info::build_schema_url("schemas/control_script.schema.json");
     try
     {
         ryml::Tree tree;
         ryml::NodeRef root = tree.rootref();
         root |= ryml::MAP;
-        root["$schema"] << "../schemas/control_script.schema.json";
+        if (format == FileFormat::JSON)
+        {
+            root["$schema"] << "../schemas/control_script.schema.json";
+        }
 
         // Add version information (git commit hash)
         const auto version = version_info::get_version_string();
@@ -394,7 +398,7 @@ void CControl_File::OnButtonExport()
             }
         }
 
-        if (!SaveConfigFile(std::filesystem::path(wpath), tree, format))
+        if (!SaveConfigFile(std::filesystem::path(wpath), tree, format, schema_url))
         {
             const auto path_u8 = to_utf8(wpath.c_str());
             spdlog::error("Failed to save control config file: {}", path_u8);

--- a/src/control/json.hpp
+++ b/src/control/json.hpp
@@ -32,6 +32,7 @@
 #include <ryml/ryml_std.hpp>
 #include <spdlog/spdlog.h>
 #include <sstream>
+#include <string_view>
 #include <vector>
 
 namespace control
@@ -164,8 +165,8 @@ inline std::expected<ryml::Tree, control::ParseError> LoadConfigFile(const std::
  * This function writes the tree to the specified file in the requested format.
  * Errors are logged via spdlog.
  */
-inline bool SaveConfigFile(const std::filesystem::path &filepath, const ryml::Tree &tree,
-                           const FileFormat format) noexcept
+inline bool SaveConfigFile(const std::filesystem::path &filepath, const ryml::Tree &tree, const FileFormat format,
+                           const std::string_view yaml_schema_url = {}) noexcept
 {
     try
     {
@@ -178,6 +179,10 @@ inline bool SaveConfigFile(const std::filesystem::path &filepath, const ryml::Tr
 
         if (format == FileFormat::YAML)
         {
+            if (!yaml_schema_url.empty())
+            {
+                ofs << "# yaml-language-server: $schema=" << yaml_schema_url << "\n";
+            }
             ofs << tree;
         }
         else

--- a/src/version_info.hpp
+++ b/src/version_info.hpp
@@ -30,11 +30,14 @@
 #pragma once
 
 #include "../generated/git_version.hpp"
+#include <format>
 #include <string>
 #include <string_view>
 
 namespace version_info
 {
+
+inline constexpr std::string_view kSchemaRepoBaseUrl = "https://raw.githubusercontent.com/takker99/DigitShowDST/";
 
 /**
  * @brief Get version string for configuration files
@@ -103,6 +106,16 @@ inline constexpr std::string_view get_commit_hash() noexcept
 inline constexpr std::string_view get_commit_hash_short() noexcept
 {
     return git_version::COMMIT_SHORT;
+}
+
+/**
+ * @brief Build a raw GitHub URL for a schema file at the build commit
+ * @param schema_path Repository-relative schema path (e.g., "schemas/control_script.schema.json")
+ * @return Raw GitHub URL pointing to the schema file at the build commit
+ */
+inline std::string build_schema_url(const std::string_view schema_path)
+{
+    return std::format("{}{}/{}", kSchemaRepoBaseUrl, get_commit_hash(), schema_path);
 }
 
 } // namespace version_info


### PR DESCRIPTION
## Summary
- add YAML schema comment support in config saving helper
- emit commit-pinned schema URLs for control and calibration YAML exports
- update API config generation to support YAML and schema comments
- document YAML schema comment usage

## Testing
- Not run (not requested)
