### PR TITLE
refactor: `Da_Cal`周りを配列のまま引き回す

### DIFF
--- a/src/DA_Pout.cpp
+++ b/src/DA_Pout.cpp
@@ -114,7 +114,7 @@ void CDA_Pout::OnBUTTONCalculation00()
 {
     // TODO: この位置にコントロール通知ハンドラ用のコードを追加してください
     UpdateData(TRUE);
-    m_DAVout[0] = static_cast<float>(control::toVoltage(m_DAPvalue[0], DA_Cal[0][1], DA_Cal[0][0]));
+    m_DAVout[0] = static_cast<float>(control::toVoltage(m_DAPvalue[0], DA_Cal[0]));
     UpdateData(FALSE);
 }
 
@@ -122,7 +122,7 @@ void CDA_Pout::OnBUTTONCalculation01()
 {
     // TODO: この位置にコントロール通知ハンドラ用のコードを追加してください
     UpdateData(TRUE);
-    m_DAVout[1] = static_cast<float>(control::toVoltage(m_DAPvalue[1], DA_Cal[1][1], DA_Cal[1][0]));
+    m_DAVout[1] = static_cast<float>(control::toVoltage(m_DAPvalue[1], DA_Cal[1]));
     UpdateData(FALSE);
 }
 
@@ -130,7 +130,7 @@ void CDA_Pout::OnBUTTONCalculation02()
 {
     // TODO: この位置にコントロール通知ハンドラ用のコードを追加してください
     UpdateData(TRUE);
-    m_DAVout[2] = static_cast<float>(control::toVoltage(m_DAPvalue[2], DA_Cal[2][1], DA_Cal[2][0]));
+    m_DAVout[2] = static_cast<float>(control::toVoltage(m_DAPvalue[2], DA_Cal[2]));
     UpdateData(FALSE);
 }
 
@@ -138,7 +138,7 @@ void CDA_Pout::OnBUTTONCalculation03()
 {
     // TODO: この位置にコントロール通知ハンドラ用のコードを追加してください
     UpdateData(TRUE);
-    m_DAVout[3] = static_cast<float>(control::toVoltage(m_DAPvalue[3], DA_Cal[3][1], DA_Cal[3][0]));
+    m_DAVout[3] = static_cast<float>(control::toVoltage(m_DAPvalue[3], DA_Cal[3]));
     UpdateData(FALSE);
 }
 
@@ -146,7 +146,7 @@ void CDA_Pout::OnBUTTONCalculation04()
 {
     // TODO: この位置にコントロール通知ハンドラ用のコードを追加してください
     UpdateData(TRUE);
-    m_DAVout[4] = static_cast<float>(control::toVoltage(m_DAPvalue[4], DA_Cal[4][1], DA_Cal[4][0]));
+    m_DAVout[4] = static_cast<float>(control::toVoltage(m_DAPvalue[4], DA_Cal[4]));
     UpdateData(FALSE);
 }
 
@@ -154,7 +154,7 @@ void CDA_Pout::OnBUTTONCalculation05()
 {
     // TODO: この位置にコントロール通知ハンドラ用のコードを追加してください
     UpdateData(TRUE);
-    m_DAVout[5] = static_cast<float>(control::toVoltage(m_DAPvalue[5], DA_Cal[5][1], DA_Cal[5][0]));
+    m_DAVout[5] = static_cast<float>(control::toVoltage(m_DAPvalue[5], DA_Cal[5]));
     UpdateData(FALSE);
 }
 
@@ -162,7 +162,7 @@ void CDA_Pout::OnBUTTONCalculation06()
 {
     // TODO: この位置にコントロール通知ハンドラ用のコードを追加してください
     UpdateData(TRUE);
-    m_DAVout[6] = static_cast<float>(control::toVoltage(m_DAPvalue[6], DA_Cal[6][1], DA_Cal[6][0]));
+    m_DAVout[6] = static_cast<float>(control::toVoltage(m_DAPvalue[6], DA_Cal[6]));
     UpdateData(FALSE);
 }
 
@@ -170,6 +170,6 @@ void CDA_Pout::OnBUTTONCalculation07()
 {
     // TODO: この位置にコントロール通知ハンドラ用のコードを追加してください
     UpdateData(TRUE);
-    m_DAVout[7] = static_cast<float>(control::toVoltage(m_DAPvalue[7], DA_Cal[7][1], DA_Cal[7][0]));
+    m_DAVout[7] = static_cast<float>(control::toVoltage(m_DAPvalue[7], DA_Cal[7]));
     UpdateData(FALSE);
 }

--- a/src/Variables.hpp
+++ b/src/Variables.hpp
@@ -27,6 +27,12 @@
 #include <numbers>
 #include <string>
 
+namespace control
+{
+inline constexpr std::size_t kVoltageCalibrationTerms = 2;
+using VoltageCalibration = std::array<double, kVoltageCalibrationTerms>;
+}
+
 namespace variables
 {
 
@@ -69,8 +75,8 @@ inline std::array<float, MAX_AI_CHANNELS> AmpPB = {};  // Physical value at base
 inline std::array<float, MAX_AI_CHANNELS> AmpPO = {};  // Physical value at offset point
 inline std::array<float, MAX_DA_CHANNELS> DAVout = {}; // Output Voltage to D/A board
 // D/A calibration stored as polynomial-ordered arrays per channel: f[0]=constant (b), f[1]=linear (a)
-inline constinit std::array<std::array<double, 2>, MAX_DA_CHANNELS> DA_Cal = []() {
-    std::array<std::array<double, 2>, MAX_DA_CHANNELS> a{};
+inline constinit std::array<control::VoltageCalibration, MAX_DA_CHANNELS> DA_Cal = []() {
+    std::array<control::VoltageCalibration, MAX_DA_CHANNELS> a{};
     // Initialize with previous DA_Cal_b (const) and DA_Cal_a (linear) mapping
     a[0] = {0.0, 0.0};
     a[1] = {0.0, 0.0};

--- a/src/control/control_output.hpp
+++ b/src/control/control_output.hpp
@@ -64,43 +64,34 @@ struct ControlOutput
     static double max_front_ep_kpa() noexcept
     {
         using namespace variables;
-        const auto min_value =
-            control::fromVoltage(MIN_VOLTAGE_OUTPUT, DA_Cal[CH_EP_Cell_f][1], DA_Cal[CH_EP_Cell_f][0]);
-        const auto max_value =
-            control::fromVoltage(MAX_VOLTAGE_OUTPUT, DA_Cal[CH_EP_Cell_f][1], DA_Cal[CH_EP_Cell_f][0]);
+        const auto min_value = control::fromVoltage(MIN_VOLTAGE_OUTPUT, DA_Cal[CH_EP_Cell_f]);
+        const auto max_value = control::fromVoltage(MAX_VOLTAGE_OUTPUT, DA_Cal[CH_EP_Cell_f]);
         return std::max(min_value, max_value);
     }
     static double min_front_ep_kpa() noexcept
     {
         using namespace variables;
-        const auto min_value =
-            control::fromVoltage(MIN_VOLTAGE_OUTPUT, DA_Cal[CH_EP_Cell_f][1], DA_Cal[CH_EP_Cell_f][0]);
-        const auto max_value =
-            control::fromVoltage(MAX_VOLTAGE_OUTPUT, DA_Cal[CH_EP_Cell_f][1], DA_Cal[CH_EP_Cell_f][0]);
+        const auto min_value = control::fromVoltage(MIN_VOLTAGE_OUTPUT, DA_Cal[CH_EP_Cell_f]);
+        const auto max_value = control::fromVoltage(MAX_VOLTAGE_OUTPUT, DA_Cal[CH_EP_Cell_f]);
         return std::min(min_value, max_value);
     }
     static double max_rear_ep_kpa() noexcept
     {
         using namespace variables;
-        const auto min_value =
-            control::fromVoltage(MIN_VOLTAGE_OUTPUT, DA_Cal[CH_EP_Cell_r][1], DA_Cal[CH_EP_Cell_r][0]);
-        const auto max_value =
-            control::fromVoltage(MAX_VOLTAGE_OUTPUT, DA_Cal[CH_EP_Cell_r][1], DA_Cal[CH_EP_Cell_r][0]);
+        const auto min_value = control::fromVoltage(MIN_VOLTAGE_OUTPUT, DA_Cal[CH_EP_Cell_r]);
+        const auto max_value = control::fromVoltage(MAX_VOLTAGE_OUTPUT, DA_Cal[CH_EP_Cell_r]);
         return std::max(min_value, max_value);
     }
     static double min_rear_ep_kpa() noexcept
     {
         using namespace variables;
-        const auto min_value =
-            control::fromVoltage(MIN_VOLTAGE_OUTPUT, DA_Cal[CH_EP_Cell_r][1], DA_Cal[CH_EP_Cell_r][0]);
-        const auto max_value =
-            control::fromVoltage(MAX_VOLTAGE_OUTPUT, DA_Cal[CH_EP_Cell_r][1], DA_Cal[CH_EP_Cell_r][0]);
+        const auto min_value = control::fromVoltage(MIN_VOLTAGE_OUTPUT, DA_Cal[CH_EP_Cell_r]);
+        const auto max_value = control::fromVoltage(MAX_VOLTAGE_OUTPUT, DA_Cal[CH_EP_Cell_r]);
         return std::min(min_value, max_value);
     }
     static double max_motor_rpm() noexcept
     {
         using namespace variables;
-        return control::fromIISMotorVoltage(5.0f, 0.0f, MAX_VOLTAGE_OUTPUT, DA_Cal[CH_MotorSpeed][1],
-                                            DA_Cal[CH_MotorSpeed][0]);
+        return control::fromIISMotorVoltage(5.0f, 0.0f, MAX_VOLTAGE_OUTPUT, DA_Cal[CH_MotorSpeed]);
     }
 };

--- a/src/control/measurement.hpp
+++ b/src/control/measurement.hpp
@@ -127,18 +127,18 @@ struct PhysicalInput
     }
 };
 
-constexpr auto toVoltage(const double physical_value, const double cal_a, const double cal_b) noexcept
+constexpr auto toVoltage(const double physical_value, const std::array<double, 2> &calibration) noexcept
 {
-    return cal_a * physical_value + cal_b;
+    return calibration[1] * physical_value + calibration[0];
 }
 
 template <typename Value = double>
-constexpr auto fromVoltage(const Value voltage, const double cal_a, const double cal_b) noexcept
+constexpr auto fromVoltage(const Value voltage, const std::array<double, 2> &calibration) noexcept
 {
-    return (voltage - cal_b) / cal_a;
+    return (voltage - calibration[0]) / calibration[1];
 }
 
-constexpr std::array<float, 3> toIISMotorVoltage(const double rpm, const double cal_a, const double cal_b) noexcept
+constexpr std::array<float, 3> toIISMotorVoltage(const double rpm, const std::array<double, 2> &calibration) noexcept
 {
     return {{
         // ON: 5.0V, OFF: 0.0V
@@ -146,16 +146,16 @@ constexpr std::array<float, 3> toIISMotorVoltage(const double rpm, const double 
         // UP: 0.0V, DOWN: 5.0V
         rpm > 0.0 ? 0.0f : 5.0f,
         // SPEED
-        static_cast<float>(toVoltage(math_constexpr::abs(rpm), cal_a, cal_b)),
+        static_cast<float>(toVoltage(math_constexpr::abs(rpm), calibration)),
     }};
 }
 
 constexpr auto fromIISMotorVoltage(const float on_voltage, const float clutch_voltage, const float speed_voltage,
-                                   const double cal_a, const double cal_b) noexcept
+                                   const std::array<double, 2> &calibration) noexcept
 {
     return on_voltage <= 0.f || speed_voltage <= 0.f
                ? 0.0
-               : math_constexpr::copysign(fromVoltage(static_cast<double>(speed_voltage), cal_a, cal_b),
+               : math_constexpr::copysign(fromVoltage(static_cast<double>(speed_voltage), calibration),
                                           clutch_voltage > 0.f ? -1.0 : 1.0);
 }
 

--- a/src/physical_variables.cpp
+++ b/src/physical_variables.cpp
@@ -38,20 +38,20 @@ void update() noexcept
     {
     }
 
-    latest_physical_output.store(
-        {control::fromVoltage(static_cast<double>(DAVout[CH_EP_Cell_f]), DA_Cal[CH_EP_Cell_f][1],
-                              DA_Cal[CH_EP_Cell_f][0]),
-         control::fromVoltage(static_cast<double>(DAVout[CH_EP_Cell_r]), DA_Cal[CH_EP_Cell_r][1],
-                              DA_Cal[CH_EP_Cell_r][0]),
-         control::fromIISMotorVoltage(DAVout[CH_Motor], DAVout[CH_MotorCruch], DAVout[CH_MotorSpeed],
-                                      DA_Cal[CH_MotorSpeed][1], DA_Cal[CH_MotorSpeed][0])});
+    latest_physical_output.store({control::fromVoltage(static_cast<double>(DAVout[CH_EP_Cell_f]),
+                                                       DA_Cal[CH_EP_Cell_f]),
+                                  control::fromVoltage(static_cast<double>(DAVout[CH_EP_Cell_r]),
+                                                       DA_Cal[CH_EP_Cell_r]),
+                                  control::fromIISMotorVoltage(DAVout[CH_Motor], DAVout[CH_MotorCruch],
+                                                               DAVout[CH_MotorSpeed],
+                                                               DA_Cal[CH_MotorSpeed])});
 }
 
 std::expected<void, std::string> set_output(const control::PhysicalOutput<> &physical) noexcept
 {
     // Convert physical values to voltages
     const auto [motor_on_voltage, motor_clutch_voltage, motor_speed_voltage] =
-        control::toIISMotorVoltage(physical.motor_rpm, DA_Cal[CH_MotorSpeed][1], DA_Cal[CH_MotorSpeed][0]);
+        control::toIISMotorVoltage(physical.motor_rpm, DA_Cal[CH_MotorSpeed]);
 
     // クラッチの消耗を抑えるため、モーターが回転していないときはクラッチを操作しない
     if (motor_speed_voltage > 0.f)
@@ -61,10 +61,8 @@ std::expected<void, std::string> set_output(const control::PhysicalOutput<> &phy
     }
     DAVout[CH_MotorSpeed] = motor_speed_voltage;
 
-    DAVout[CH_EP_Cell_f] =
-        static_cast<float>(control::toVoltage(physical.front_ep_kpa, DA_Cal[CH_EP_Cell_f][1], DA_Cal[CH_EP_Cell_f][0]));
-    DAVout[CH_EP_Cell_r] =
-        static_cast<float>(control::toVoltage(physical.rear_ep_kpa, DA_Cal[CH_EP_Cell_r][1], DA_Cal[CH_EP_Cell_r][0]));
+    DAVout[CH_EP_Cell_f] = static_cast<float>(control::toVoltage(physical.front_ep_kpa, DA_Cal[CH_EP_Cell_f]));
+    DAVout[CH_EP_Cell_r] = static_cast<float>(control::toVoltage(physical.rear_ep_kpa, DA_Cal[CH_EP_Cell_r]));
 
     if (auto result = digitshow::write_analog_outputs(); !result)
     {


### PR DESCRIPTION
記述量の削減目的。 x^2項以降の校正係数などの実装に容易に対応できるようにした。