### PR TITLE
build: Github Copilot coding agentで`msbuild`を使えるようにした

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,6 +42,8 @@ DigitShowDST is a **legacy MFC single-document/single-view C++ application** for
 ## Build & Runtime
 - Build through VS Code tasks (`MSBuild: Build Release`, `MSBuild: Build Debug`), which bootstrap `Load-DevEnv.ps1` automatically.
 - Manual builds: `msbuild .\DigitShowDST.vcxproj /t:Build /p:Configuration=Release` (requires VS Dev Shell initialized via `Load-DevEnv.ps1`).
+- In Copilot coding agent sessions, environment setup is handled by `.github/workflows/copilot-setup-steps.yml` at agent startup.
+- Do **not** run `Load-DevEnv.ps1` in coding agent workflows; `microsoft/setup-msbuild` already configures `msbuild` in `PATH`.
 - No automated test harness yet; validate by exercising the GUI. Add hardware fallbacks (check `Flag_SetBoard`) whenever touching real I/O so agents can run without boards.
 
 ## Python Tooling

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
             vcpkg-${{ runner.os }}-
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1.3
+        uses: microsoft/setup-msbuild@v2
 
       - name: Build
         shell: cmd

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -22,6 +22,22 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Setup vcpkg binary sources
+        shell: pwsh
+        run: |
+          echo "VCPKG_BINARY_SOURCES=clear;files,${{ runner.temp }}/vcpkg_cache,readwrite" >> $env:GITHUB_ENV
+
+      - name: Cache vcpkg
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ runner.temp }}/vcpkg_cache
+            vcpkg_installed
+          key: vcpkg-${{ runner.os }}-x64-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-x64-
+            vcpkg-${{ runner.os }}-
+
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,30 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # IMPORTANT: This job id must be exactly "copilot-setup-steps" for Copilot coding agent.
+  copilot-setup-steps:
+    runs-on: windows-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Build Release x64
+        shell: cmd
+        run: msbuild .\DigitShowDST.vcxproj /t:Build /p:Configuration=Release /p:Platform=x64 /m


### PR DESCRIPTION
https://github.blog/changelog/2026-02-18-use-copilot-coding-agent-with-windows-projects/

で対応したwindows runnerを使う。