### PR TITLE
fix: 変換時間を全チャンネル合計1ms確保する

### DIFF
--- a/src/Variables.hpp
+++ b/src/Variables.hpp
@@ -31,7 +31,7 @@ namespace control
 {
 inline constexpr std::size_t kVoltageCalibrationTerms = 2;
 using VoltageCalibration = std::array<double, kVoltageCalibrationTerms>;
-}
+} // namespace control
 
 namespace variables
 {

--- a/src/aio_wrapper.hpp
+++ b/src/aio_wrapper.hpp
@@ -275,6 +275,38 @@ namespace aio
 }
 
 /**
+ * @brief Set analog input scan clock
+ * @param id Device ID
+ * @param scanClock Scan clock period in microseconds
+ * @return Expected with void or UTF-8 error message
+ */
+[[nodiscard]] inline std::expected<void, std::string> setAiScanClock(const short id, const float scanClock) noexcept
+{
+    const auto ret = AioSetAiScanClock(id, scanClock);
+    if (ret != 0)
+    {
+        return std::unexpected(get_error_message(ret));
+    }
+    return {};
+}
+
+/**
+ * @brief Get analog input scan clock
+ * @param id Device ID
+ * @return Expected with scan clock or UTF-8 error message
+ */
+[[nodiscard]] inline std::expected<float, std::string> getAiScanClock(const short id) noexcept
+{
+    float scanClock = 0.0f;
+    const auto ret = AioGetAiScanClock(id, &scanClock);
+    if (ret != 0)
+    {
+        return std::unexpected(get_error_message(ret));
+    }
+    return scanClock;
+}
+
+/**
  * @brief Set analog input event sampling times
  * @param id Device ID
  * @param samplingTimes Number of sampling times

--- a/src/board_control.cpp
+++ b/src/board_control.cpp
@@ -137,7 +137,16 @@ std::expected<InitResult, std::string> InitializeBoards(
                                     return aio::setAiChannels(AdId[i], channels);
                                 })
                                 .and_then([&]() { return aio::setAiRangeAll(AdId[i], 0); })
-                                .and_then([&]() { return aio::getAiRange(AdId[i], 0); })
+                                .and_then([&]() {
+                                    // ScanClock制御: 1000 us / maxChannels (参考: DigitShowBasic)
+                                    const float scanClock = 1000.0f / static_cast<float>(AdChannels[i]);
+                                    return aio::setAiScanClock(AdId[i], scanClock);
+                                })
+                                .and_then([&]() { return aio::getAiScanClock(AdId[i]); })
+                                .and_then([&](float scanClock) {
+                                    spdlog::debug("A/D board {} scan clock: {} us", i, scanClock);
+                                    return aio::getAiRange(AdId[i], 0);
+                                })
                                 .transform([&](short range) {
                                     AdRange[i] = range;
                                     return GetRangeValue(range, &adRangeMax[i], &adRangeMin[i]);

--- a/src/physical_variables.cpp
+++ b/src/physical_variables.cpp
@@ -38,13 +38,10 @@ void update() noexcept
     {
     }
 
-    latest_physical_output.store({control::fromVoltage(static_cast<double>(DAVout[CH_EP_Cell_f]),
-                                                       DA_Cal[CH_EP_Cell_f]),
-                                  control::fromVoltage(static_cast<double>(DAVout[CH_EP_Cell_r]),
-                                                       DA_Cal[CH_EP_Cell_r]),
+    latest_physical_output.store({control::fromVoltage(static_cast<double>(DAVout[CH_EP_Cell_f]), DA_Cal[CH_EP_Cell_f]),
+                                  control::fromVoltage(static_cast<double>(DAVout[CH_EP_Cell_r]), DA_Cal[CH_EP_Cell_r]),
                                   control::fromIISMotorVoltage(DAVout[CH_Motor], DAVout[CH_MotorCruch],
-                                                               DAVout[CH_MotorSpeed],
-                                                               DA_Cal[CH_MotorSpeed])});
+                                                               DAVout[CH_MotorSpeed], DA_Cal[CH_MotorSpeed])});
 }
 
 std::expected<void, std::string> set_output(const control::PhysicalOutput<> &physical) noexcept


### PR DESCRIPTION
これを設定しないと、ほんのわずかな時間しかAD変換しないため、値が不安定になる。